### PR TITLE
Add "er-open-button"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ component available in your application.
 *Remember to add the `remodal-bg` class to anything in your app that you want
 blurred while a modal is open!*
 
+### Included Components
+- `ember-remodal`: This is the base component for ember-remodal. This
+component renders and controls a modal in your application. Example:
+
+  ```hbs
+    {{ember-remodal openButton='Open!' text='Text inside a modal.'}}
+  ```
+
+- `er-open-button`: Placed in the block of an `ember-remodal`, this optional
+component allows you to specify your own html to act as the "open button" for a
+modal. Example:
+
+  ```hbs
+    {{#ember-remodal}}
+      <p>This will show up inside the modal</p>
+
+      {{#er-open-button}}
+        <!-- You can put anything you want in here
+        and it will render outside the modal, opening
+        the modal when clicked -->
+      {{/er-open-button}}
+
+      <p>This will also show up inside the modal</p>
+    {{/ember-remodal}}
+  ```
+
 ### Options Summary
 
 #### Remodal Options

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ January 17th 2016.
 # ember-remodal
 [![Build Status](https://travis-ci.org/sethbrasile/ember-remodal.svg?branch=master)](https://travis-ci.org/sethbrasile/ember-remodal) [![npm version](https://badge.fury.io/js/ember-remodal.svg)](http://badge.fury.io/js/ember-remodal) [![Ember Observer Score](http://emberobserver.com/badges/ember-remodal.svg)](http://emberobserver.com/addons/ember-remodal)
 
-*This README is up-to-date and accurate as of ember-remodal v0.0.9*
+*This README is up-to-date and accurate as of ember-remodal v0.0.11*
 
 There are many modal addons for Ember, but most of them (in my experience) are
 only useful in a very specific situation. Often, when building large apps, you

--- a/README.md
+++ b/README.md
@@ -121,10 +121,6 @@ rendered below the `title`/`text`, or by itself if no `title`/`text` are provide
 
 ### Simplest Use-Case
 
-*If you will be using more than a couple modals in your application,
-please read through here to understand how many of the options work, but refer
-to the [using ember-remodal as a service][1] section for implementation*
-
 Apply the `remodal-bg` class to anything on your page that you would like blurred
 while the modal is open. A common pattern would be to apply this class to a `div`
 that is wrapping your entire application. This is completely optional, this modal

--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -83,6 +83,10 @@ export default Component.extend({
     });
   },
 
+  registerButton(button) {
+    this.set('customButton', button);
+  },
+
   actions: {
     confirm() {
       this.sendAction('onConfirm');

--- a/addon/components/er-open-button.js
+++ b/addon/components/er-open-button.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import EmberRemodal from './ember-remodal';
+import layout from '../templates/components/er-open-button';
+
+const {
+  assert,
+  computed,
+  run: { scheduleOnce },
+  Component
+} = Ember;
+
+export default Component.extend({
+  layout,
+
+  tagName: 'span',
+  modal: null,
+
+  didInitAttrs() {
+    scheduleOnce('afterRender', this, '_registerWithModal');
+  },
+
+  _registerWithModal() {
+    const modal = this.nearestOfType(EmberRemodal);
+    assert('An "er-open-button" MUST be declared inside an "ember-remodal" component block.', !!modal);
+    modal.registerButton(this);
+    this.set('modal', modal);
+  },
+
+  destination: computed('modal', {
+    get() {
+      const modalId = this.get('modal.elementId');
+
+      if (modalId) {
+        return `button-outlet-for-${modalId}`;
+      }
+    }
+  })
+});

--- a/addon/templates/components/ember-remodal.hbs
+++ b/addon/templates/components/ember-remodal.hbs
@@ -1,4 +1,6 @@
-{{#if linkButton}}
+{{#if customButton}}
+  <span {{action 'open'}} id="button-outlet-for-{{elementId}}"></span>
+{{else if linkButton}}
   <a {{action 'open'}} href="#" class="ember-remodal outer link text {{buttonClasses}} {{outerButtonClasses}}" data-test-id="linkButton">{{linkButton}}</a>
 {{else if openLink}}
   <a {{action 'open'}} href="#" class="ember-remodal outer link text {{buttonClasses}} {{outerButtonClasses}}" data-test-id="openLink">{{openLink}}</a>

--- a/addon/templates/components/er-open-button.hbs
+++ b/addon/templates/components/er-open-button.hbs
@@ -1,0 +1,5 @@
+{{#if destination}}
+  {{#ember-wormhole to=destination}}
+    {{yield}}
+  {{/ember-wormhole}}
+{{/if}}

--- a/app/components/er-open-button.js
+++ b/app/components/er-open-button.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-remodal/components/er-open-button';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-suave": "1.2.3",
-    "ember-try": "~0.0.8"
+    "ember-try": "~0.0.8",
+    "ember-wormhole": "0.3.4"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,4 @@
+.custom-button {
+  background-color: black;
+  color: white;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -11,8 +11,6 @@
   <button {{action 'showApplicationModal2'}}>Show Service Modal 2</button>
   <button {{action 'showApplicationModal3'}}>Show Service Modal 3</button>
 
-  {{outlet}}
-
   {{ember-remodal forService=true onOpen='onOpenWasFired' onClose='onCloseWasFired'}}
 
   {{#ember-remodal forService=true name='appModal2' title='Named Modal triggered with the "remodal" service'}}
@@ -25,5 +23,21 @@
   {{#ember-remodal openButton='Invisible Modal' disableForeground=true}}
     This is white text over the "overlay" background.
     The normal white modal background is hidden.
+  {{/ember-remodal}}
+
+  {{#ember-remodal}}
+    {{#er-open-button}}
+      <button class='custom-button'>OPEN A MODAL!</button>
+    {{/er-open-button}}
+
+    <p>This is content placed inside an ember-remodal's block along with an "er-open-button"</p>
+  {{/ember-remodal}}
+
+  {{#ember-remodal}}
+    {{#er-open-button}}
+      <button class='custom-button'>OPEN A 2nd MODAL!</button>
+    {{/er-open-button}}
+
+    <p>This is content placed inside a 2nd ember-remodal's block along with an "er-open-button"</p>
   {{/ember-remodal}}
 </div>

--- a/tests/integration/components/er-open-button-test.js
+++ b/tests/integration/components/er-open-button-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('er-open-button', 'Integration | Component | er open button', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{er-open-button}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:" + EOL +
+  this.render(hbs`
+    {{#er-open-button}}
+      template block text
+    {{/er-open-button}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/er-open-button-test.js
+++ b/tests/integration/components/er-open-button-test.js
@@ -6,19 +6,26 @@ moduleForComponent('er-open-button', 'Integration | Component | er open button',
 });
 
 test('it renders', function(assert) {
-  
+
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
 
-  this.render(hbs`{{er-open-button}}`);
+  this.render(hbs`
+    {{#ember-remodal}}
+      {{#er-open-button}}
+      {{/er-open-button}}
+    {{/ember-remodal}}
+  `);
 
   assert.equal(this.$().text().trim(), '');
 
   // Template block usage:" + EOL +
   this.render(hbs`
-    {{#er-open-button}}
-      template block text
-    {{/er-open-button}}
+    {{#ember-remodal}}
+      {{#er-open-button}}
+        template block text
+      {{/er-open-button}}
+    {{/ember-remodal}}
   `);
 
   assert.equal(this.$().text().trim(), 'template block text');


### PR DESCRIPTION
"er-open-button" is a new component which you can place anywhere inside an `ember-remodal` block, and it will always be rendered outside the modal as the open button for a modal. It allows one to specify "custom" html to act as an open button.