### PR TITLE
Config flag to disable animations during testing

### DIFF
--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -5,6 +5,7 @@ const {
   inject,
   computed,
   computed: { reads },
+  getOwner,
   on,
   RSVP: { Promise },
   run: { next, scheduleOnce },
@@ -50,6 +51,7 @@ export default Component.extend({
 
     scheduleOnce('afterRender', this, '_registerObservers');
     scheduleOnce('afterRender', this, '_checkForDeprecations');
+    scheduleOnce('afterRender', this, '_checkForTestingEnv');
   },
 
   willDestroyElement() {
@@ -150,6 +152,28 @@ export default Component.extend({
 
   _checkForDeprecations() {
     // Deprecations go here
+  },
+
+  _checkForTestingEnv() {
+    let config = this._getConfig();
+
+    if (config) {
+      let env = config.environment;
+      let remodalConfig = config['ember-remodal'];
+      let disableAnimation;
+
+      if (remodalConfig) {
+        disableAnimation = remodalConfig.disableAnimationWhileTesting;
+      }
+
+      if (disableAnimation && env === 'test') {
+        this.set('disableAnimation', true);
+      }
+    }
+  },
+
+  _getConfig() {
+    return getOwner(this).resolveRegistration('config:environment');
   },
 
   _openModal() {

--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -39,16 +39,7 @@ export default Component.extend({
   erConfirmButton: false,
 
   didInsertElement() {
-    let opts = this.get('options');
-
-    if (opts) {
-      this.setProperties(opts);
-    }
-
-    if (this.get('forService')) {
-      this.get('remodal').set(this.get('name'), this);
-    }
-
+    scheduleOnce('afterRender', this, '_setProperties');
     scheduleOnce('afterRender', this, '_registerObservers');
     scheduleOnce('afterRender', this, '_checkForDeprecations');
     scheduleOnce('afterRender', this, '_checkForTestingEnv');
@@ -115,6 +106,18 @@ export default Component.extend({
       return `${action}d`;
     } else {
       return `${action}ed`;
+    }
+  },
+
+  _setProperties() {
+    let opts = this.get('options');
+
+    if (opts) {
+      this.setProperties(opts);
+    }
+
+    if (this.get('forService')) {
+      this.get('remodal').set(this.get('name'), this);
     }
   },
 

--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -37,7 +37,7 @@ export default Component.extend({
   erCancelButton: false,
   erConfirmButton: false,
 
-  didInitAttrs() {
+  didInsertElement() {
     let opts = this.get('options');
 
     if (opts) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -35,6 +35,9 @@
           {{link-to 'Styling' 'styling'}}
         </li>
         <li>
+          {{link-to 'Testing' 'options.testing'}}
+        </li>
+        <li>
           {{link-to 'Upgrade Guide' 'upgrading'}}
         </li>
       </ul>

--- a/tests/dummy/app/templates/options/testing.hbs
+++ b/tests/dummy/app/templates/options/testing.hbs
@@ -1,20 +1,40 @@
 <div class="content">
-  <h3>Testing</h3>
+  <h2>Testing</h2>
 
-  <p>
-    By adding the <code>dataTestId</code> option, you can easily target a
-    specific modal's <code>openButton</code> in your tests.
-  </p>
+  <div class="content">
+    <h3>Globally Disabling Modal Animations While Testing</h3>
+    <br>
+    <p>
+      You may find it useful to globally disable all modal animations during
+      tests. To do so, set <code>disableAnimationWhileTesting</code> to
+      <code>true</code> in your <code>config/environment</code>:
+
+{{#code-block language='javascript'}}
+  'ember-remodal': {
+    disableAnimationWhileTesting: true
+  }
+{{/code-block}}
+
+    </p>
+  </div>
+
+  <div class="content">
+    <h3>Using the <code>data-test-id</code> selector pattern</h3>
+    <br>
+    <p>
+      By adding the <code>dataTestId</code> option, you can easily target a
+      specific modal's <code>openButton</code> in your tests.
+    </p>
 
 {{#code-block language='javascript'}}
   \{{ember-remodal openButton='Click Me' dataTestId='simple-inline-modal'}}
 {{/code-block}}
 
-<p>
-  Only one modal can be open at a time, so once the modal that you're targeting
-  has been opened, you can target the generic <code>data-test-id</code>
-  <code>modalWindow</code>.
-</p>
+  <p>
+    Only one modal can be open at a time, so once the modal that you're targeting
+    has been opened, you can target the generic <code>data-test-id</code>
+    <code>modalWindow</code>.
+  </p>
 
 {{#code-block language='javascript'}}
   moduleForAcceptance('Acceptance | simple inline modal', {
@@ -41,10 +61,10 @@
   });
 {{/code-block}}
 
-<p>
-  Inside the <code>modalWindow</code>, all the included buttons have a
-  <code>data-test-id</code> that corresponds to their option name.
-</p>
+  <p>
+    Inside the <code>modalWindow</code>, all the included buttons have a
+    <code>data-test-id</code> that corresponds to their option name.
+  </p>
 
 {{#code-block language='javascript'}}
   test('it has a confirm button', function(assert) {
@@ -57,4 +77,5 @@
     });
   });
 {{/code-block}}
+  </div>
 </div>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -6,6 +6,9 @@ module.exports = function(environment) {
     environment: environment,
     baseURL: '/',
     locationType: 'auto',
+    'ember-remodal': {
+      disableAnimationWhileTesting: true
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/unit/components/ember-remodal-test.js
+++ b/tests/unit/components/ember-remodal-test.js
@@ -399,7 +399,7 @@ test('"_checkForTestingEnv" sets "disableAnimation" to true when "disableAnimati
 
   component.set('_getConfig', () => {
     return {
-      environment: 'testing',
+      environment: 'test',
       'ember-remodal': {
         disableAnimationWhileTesting: true
       }
@@ -418,7 +418,7 @@ test('"_checkForTestingEnv" leaves "disableAnimation" alone when "disableAnimati
 
   component.set('_getConfig', () => {
     return {
-      environment: 'testing',
+      environment: 'test',
       'ember-remodal': {
         disableAnimationWhileTesting: false
       }
@@ -430,7 +430,7 @@ test('"_checkForTestingEnv" leaves "disableAnimation" alone when "disableAnimati
   assert.notOk(component.get('disableAnimation'));
 });
 
-test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "testing"', function(assert) {
+test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "test"', function(assert) {
   assert.expect(2);
 
   let component = this.subject();
@@ -449,7 +449,7 @@ test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is 
   assert.notOk(component.get('disableAnimation'));
 });
 
-test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "testing" and "disableAnimation" was manually set to "true"', function(assert) {
+test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "test" and "disableAnimation" was manually set to "true"', function(assert) {
   assert.expect(2);
 
   let component = this.subject({ disableAnimation: true });

--- a/tests/unit/components/ember-remodal-test.js
+++ b/tests/unit/components/ember-remodal-test.js
@@ -374,3 +374,96 @@ test('"_destroyDomElements" calls "destroy" on "modal"', function(assert) {
     assert.ok(component.get('modal.destroyCalled'));
   });
 });
+
+test('"_checkForTestingEnv" is called on "didInsertElement"', function(assert) {
+  assert.expect(2);
+
+  run(() => {
+    let component = this.subject({
+      checkForTestingCalled: false,
+      _checkForTestingEnv() {
+        this.set('checkForTestingCalled', true);
+      }
+    });
+
+    assert.notOk(component.get('checkForTestingCalled'));
+    this.render();
+    assert.ok(component.get('checkForTestingCalled'));
+  });
+});
+
+test('"_checkForTestingEnv" sets "disableAnimation" to true when "disableAnimationWhileTesting" is true in config', function(assert) {
+  assert.expect(2);
+
+  let component = this.subject();
+
+  component.set('_getConfig', () => {
+    return {
+      environment: 'testing',
+      'ember-remodal': {
+        disableAnimationWhileTesting: true
+      }
+    };
+  });
+
+  assert.notOk(component.get('disableAnimation'));
+  component._checkForTestingEnv();
+  assert.ok(component.get('disableAnimation'));
+});
+
+test('"_checkForTestingEnv" leaves "disableAnimation" alone when "disableAnimationWhileTesting" is false/undefined in config', function(assert) {
+  assert.expect(2);
+
+  let component = this.subject();
+
+  component.set('_getConfig', () => {
+    return {
+      environment: 'testing',
+      'ember-remodal': {
+        disableAnimationWhileTesting: false
+      }
+    };
+  });
+
+  assert.notOk(component.get('disableAnimation'));
+  component._checkForTestingEnv();
+  assert.notOk(component.get('disableAnimation'));
+});
+
+test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "testing"', function(assert) {
+  assert.expect(2);
+
+  let component = this.subject();
+
+  component.set('_getConfig', () => {
+    return {
+      environment: 'development',
+      'ember-remodal': {
+        disableAnimationWhileTesting: true
+      }
+    };
+  });
+
+  assert.notOk(component.get('disableAnimation'));
+  component._checkForTestingEnv();
+  assert.notOk(component.get('disableAnimation'));
+});
+
+test('"_checkForTestingEnv" leaves "disableAnimation" alone when environment is not "testing" and "disableAnimation" was manually set to "true"', function(assert) {
+  assert.expect(2);
+
+  let component = this.subject({ disableAnimation: true });
+
+  component.set('_getConfig', () => {
+    return {
+      environment: 'development',
+      'ember-remodal': {
+        disableAnimationWhileTesting: true
+      }
+    };
+  });
+
+  assert.ok(component.get('disableAnimation'));
+  component._checkForTestingEnv();
+  assert.ok(component.get('disableAnimation'));
+});


### PR DESCRIPTION
Adds support for an optional flag in consuming app’s config which, if `true`, disables animations for all modals automatically when `environment === ‘test’`

```
‘ember-remodal’: {
  disableAnimationWhileTesting: <bool>
}
```