### PR TITLE
Fix import in engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,17 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
+    // In nested addons, app.bowerDirectory might not be available
+    var bowerDirectory = app.bowerDirectory || 'bower_components';
+    // In ember-cli < 2.7, this.import is not available, so fall back to use app.import
+    var importShim = typeof this.import !== 'undefined' ? this : app;
+
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import(app.bowerDirectory + '/remodal/dist/remodal.js');
+      importShim.import(bowerDirectory + '/remodal/dist/remodal.js');
     }
 
-    app.import(app.bowerDirectory + '/remodal/dist/remodal.css');
-    app.import(app.bowerDirectory + '/remodal/dist/remodal-default-theme.css');
-    app.import('vendor/style.css');
+    importShim.import(bowerDirectory + '/remodal/dist/remodal.css');
+    importShim.import(bowerDirectory + '/remodal/dist/remodal-default-theme.css');
+    importShim.import('vendor/style.css');
   }
 };


### PR DESCRIPTION
In an engine, CLI throws an error because `app.import` and `app.bowerDirectory` don't work. This PR makes it possible to use this addon in an engine, by 1.) using `this.import` if available (ember-cli >+ 2.7) and 2.) making `bowerDirectory` fall back to `bower_components` if `app.bowerDirectroy` is not available.