### PR TITLE
Add option to configure content rendering in block form

### DIFF
--- a/addon/templates/components/ember-remodal.hbs
+++ b/addon/templates/components/ember-remodal.hbs
@@ -23,13 +23,15 @@
   {{/if}}
 
   {{#if hasBlock}}
-    <div class="ember-remodal inner yielded content" data-test-id="yielded">
-      {{yield (hash
-        open=(component 'ember-remodal/er-button' modalId=elementId)
-        confirm=(component 'ember-remodal/er-button' action=(action 'confirm'))
-        cancel=(component 'ember-remodal/er-button' action=(action 'cancel'))
-      )}}
-    </div>
+    {{#if shouldRenderBlock}}
+      <div class="ember-remodal inner yielded content" data-test-id="yielded">
+        {{yield (hash
+          open=(component 'ember-remodal/er-button' modalId=elementId)
+          confirm=(component 'ember-remodal/er-button' action=(action 'confirm'))
+          cancel=(component 'ember-remodal/er-button' action=(action 'cancel'))
+        )}}
+      </div>
+    {{/if}}
   {{/if}}
 
   {{#if cancelButton}}


### PR DESCRIPTION
`yieldedContentRendering`:
- 'always': render always (by default, old behaviour);
- 'lazy': render since the first opening;
- 'open': render only when modal is open, content is destroyed on closing.

Closes #40.