### PR TITLE
fix: Add all required Prism components explicitly to fix tests

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,9 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": {
+    "search": [
+      "https://registry.bower.io"
+    ]
+  }
 }

--- a/coverage.json
+++ b/coverage.json
@@ -1,25 +1,25 @@
 {
   "stats": {
-    "suites": 117,
+    "suites": 118,
     "tests": 171,
     "passes": 171,
     "pending": 0,
     "failures": 0,
-    "start": "2016-06-29T04:55:08.030Z",
-    "end": "2016-06-29T04:55:12.428Z"
+    "start": "2018-09-20T17:24:53.837Z",
+    "end": "2018-09-20T17:24:58.224Z"
   },
   "coverage": {
     "total": {
       "statementsTotal": 119,
-      "statementsCovered": 117,
-      "percentage": 98.32
+      "statementsCovered": 119,
+      "percentage": 100
     },
     "files": [
       {
         "name": "ember-remodal/components/ember-remodal",
         "statementsTotal": 87,
-        "statementsCovered": 85,
-        "percentage": 97.7
+        "statementsCovered": 87,
+        "percentage": 100
       },
       {
         "name": "dummy/components/ember-remodal/er-button",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,7 @@ module.exports = function(defaults) {
 
     'ember-prism': {
       theme: 'okaidia',
-      components: ['javascript', 'handlebars']
+      components: ['javascript', 'handlebars', 'markup-templating']
     }
   });
 

--- a/testem.js
+++ b/testem.js
@@ -6,8 +6,5 @@ module.exports = {
   "launch_in_ci": [
     "PhantomJS"
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  "launch_in_dev": []
 };


### PR DESCRIPTION
Hey!

Tests where failing because of this error: https://github.com/shipshapecode/ember-prism/issues/29. 
This PR adds the required dependencies and updates the bower registry because the one that the addon was pointing to was removed.

After doing this, tests are passing locally. 

Best regards,
Daniel.