### PR TITLE
quick-fix: Importing warn from @ember/debug seems to be broken

### DIFF
--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -12,12 +12,12 @@ import { scheduleOnce, next } from '@ember/runloop';
 import { sendEvent } from '@ember/object/events';
 import Component from '@ember/component';
 import layout from '../templates/components/ember-remodal';
-import { warn } from '@ember/debug';
+import { warn as emberWarn } from '@ember/debug';
 
 export default Component.extend({
   layout,
   warn() {
-    return warn;
+    return emberWarn;
   },
   remodal: service(),
   attributeBindings: ['dataTestId:data-test-id'],

--- a/addon/components/ember-remodal.js
+++ b/addon/components/ember-remodal.js
@@ -12,13 +12,10 @@ import { scheduleOnce, next } from '@ember/runloop';
 import { sendEvent } from '@ember/object/events';
 import Component from '@ember/component';
 import layout from '../templates/components/ember-remodal';
-import { warn as emberWarn } from '@ember/debug';
+import Ember from 'ember';
 
 export default Component.extend({
   layout,
-  warn() {
-    return emberWarn;
-  },
   remodal: service(),
   attributeBindings: ['dataTestId:data-test-id'],
   classNames: ['remodal-component'],
@@ -39,6 +36,10 @@ export default Component.extend({
   erOpenButton: false,
   erCancelButton: false,
   erConfirmButton: false,
+
+  warn() {
+    Ember.warn;
+  },
 
   didInsertElement() {
     scheduleOnce('afterRender', this, '_setProperties');


### PR DESCRIPTION
#Description

Fix problem with `warn` import. The error is described here: https://github.com/emberjs/ember.js/issues/16139

I just found this quick fix solution, but it could be a better one. 